### PR TITLE
Fix issue #18 - Use correct value of field label in multifield listing.

### DIFF
--- a/multifield.admin.inc
+++ b/multifield.admin.inc
@@ -17,9 +17,13 @@ function multifield_list_page() {
   $rows = array();
   foreach (multifield_load_all() as $machine_name => $multifield) {
     $row = array('data' => array());
+
+    // Get the multifield details needed for the 'Label' and 'Used as field in' columns.
     $fields = _multifield_get_usage_summary($machine_name, TRUE);
-    $label = key($fields);
-    $row['data'][] = $label;
+    $field_used_as = array();
+    $field_used_as[] = $fields['used_as'];
+
+    $row['data'][] = $fields['label'];
     $row['data'][] = check_plain($machine_name);
 
     $subfields = field_info_instances('multifield', $machine_name);
@@ -36,9 +40,7 @@ function multifield_list_page() {
         break;
     }
 
-    $fields = _multifield_get_usage_summary($machine_name, TRUE);
-    $row['data'][] = !empty($fields) ? theme('item_list', array('items' => $fields)) : t('None');
-
+    $row['data'][] = !empty($fields) ? theme('item_list', array('items' => $field_used_as)) : t('None');
     $base = 'admin/structure/multifield/manage/' . $machine_name;
     $operations = array();
     if (multifield_edit_access($multifield)) {
@@ -199,11 +201,13 @@ function _multifield_get_usage_summary($machine_name, $links = FALSE) {
     $field = field_info_field($field_name);
     foreach ($field['bundles'] as $entity_type => $bundles) {
       foreach ($bundles as $bundle) {
+        // Get the label for this instance of the multifield.
         $label = config_get("field.instance.$entity_type.$bundle.$field_name",'label');
+        // Construct the link for admin of the multifield settings.
         $text = "$field_name ($entity_type:$bundle)";
         if ($links && module_exists('field_ui')) {
           $path = _field_ui_bundle_admin_path($entity_type, $bundle) . '/fields/' . $field_name;
-          $fields[$label] = l($text, $path);
+          $fields = array('used_as' => l($text, $path),'label' => $label);
         }
         else {
           $fields[] = check_plain($text);

--- a/multifield.admin.inc
+++ b/multifield.admin.inc
@@ -17,7 +17,9 @@ function multifield_list_page() {
   $rows = array();
   foreach (multifield_load_all() as $machine_name => $multifield) {
     $row = array('data' => array());
-    $row['data'][] = check_plain($multifield->label);
+    $fields = _multifield_get_usage_summary($machine_name, TRUE);
+    $label = key($fields);
+    $row['data'][] = $label;
     $row['data'][] = check_plain($machine_name);
 
     $subfields = field_info_instances('multifield', $machine_name);
@@ -197,10 +199,11 @@ function _multifield_get_usage_summary($machine_name, $links = FALSE) {
     $field = field_info_field($field_name);
     foreach ($field['bundles'] as $entity_type => $bundles) {
       foreach ($bundles as $bundle) {
+        $label = config_get("field.instance.$entity_type.$bundle.$field_name",'label');
         $text = "$field_name ($entity_type:$bundle)";
         if ($links && module_exists('field_ui')) {
           $path = _field_ui_bundle_admin_path($entity_type, $bundle) . '/fields/' . $field_name;
-          $fields[] = l($text, $path);
+          $fields[$label] = l($text, $path);
         }
         else {
           $fields[] = check_plain($text);

--- a/multifield.views.inc
+++ b/multifield.views.inc
@@ -61,7 +61,7 @@ function multifield_field_views_data($field) {
                 $table[$field_name.'_'.$subfield_name.'_value']['group'] = 'Multifield';
                 $table[$field_name.'_'.$subfield_name.'_value']['title short'] = $table[$field_name]['title'].':'.$table[$field_name.'_'.$subfield_name.'_value'][$handler]['field_name'];
                 // Overwrite field_name.
-								$table[$f_data['field']['additional fields'][$index]][$handler]['field_name'] = $subfield_data['field_data_' . $subfield_name][$source_field]['title short'];
+                $table[$f_data['field']['additional fields'][$index]][$handler]['field_name'] = $subfield_data['field_data_' . $subfield_name][$source_field]['title short'];
                 // Overwrite handler.
                 $table[$f_data['field']['additional fields'][$index]][$handler]['handler'] = $subfield_data['field_data_' . $subfield_name][$source_field][$handler]['handler'];
                 // Add additional options without overwriting table etc.

--- a/multifield.views.inc
+++ b/multifield.views.inc
@@ -57,8 +57,11 @@ function multifield_field_views_data($field) {
             }
             foreach (array('argument', 'filter', 'sort') as $handler) {
               if (isset($subfield_data['field_data_' . $subfield_name][$source_field][$handler]) && isset($table[$f_data['field']['additional fields'][$index]][$handler])) {
+                // Overwrite subfield group and title short values.
+                $table[$field_name.'_'.$subfield_name.'_value']['group'] = 'Multifield';
+                $table[$field_name.'_'.$subfield_name.'_value']['title short'] = $table[$field_name]['title'].':'.$table[$field_name.'_'.$subfield_name.'_value'][$handler]['field_name'];
                 // Overwrite field_name.
-                $table[$f_data['field']['additional fields'][$index]][$handler]['field_name'] = $subfield_data['field_data_' . $subfield_name][$source_field][$handler]['field_name'];
+								$table[$f_data['field']['additional fields'][$index]][$handler]['field_name'] = $subfield_data['field_data_' . $subfield_name][$source_field]['title short'];
                 // Overwrite handler.
                 $table[$f_data['field']['additional fields'][$index]][$handler]['handler'] = $subfield_data['field_data_' . $subfield_name][$source_field][$handler]['handler'];
                 // Add additional options without overwriting table etc.


### PR DESCRIPTION
The fix modifies ```function _multifield_get_usage_summary()``` by obtaining the value of the label from the relevant field.instance config file and returning it as the key of array ```$fields```.